### PR TITLE
Better sentinel handling in a subfolder, prepare for CI, venv, ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,54 @@ This cookiecutter templates result helps in
 
   Best is to install the two tools into your standard Python 3 (not the venv inside the project).
 
+## Options
+
+`project_name`
+    Name of the project or addon.
+    In mode *standalone* just the target folder name;
+    in mode *addon* the dotted name of the package.
+
+`mode`
+    - `standalone` (default): generate a build system for a Plone site,
+      but folder does not direcly contain a source package (like generated with *plonecli*).
+    - `addon`: generate a integrated build for an addon.
+
+`requirements-out`
+    *mexdev* is used to help with development with sources on top f stable constraints.
+    It generates a pip requirements file.
+    Configure here how the file is named.
+    Default: `requirements-mxdev.txt`.
+`admin_user`
+    *cookiecutter-zope-instance* is used to generate an instance configuration for the Plone/Zope application server.
+    It creates an initial user with full access.
+    This is the username.
+    Default: `admin`.
+`admin_user`
+    *cookiecutter-zope-instance* is used to generate an instance configuration for the Plone/Zope application server.
+    It creates an initial user with full access.
+    This is the password.
+    If empty a password is generated.
+    Default: empty.
+`plone_version`
+    Plone Release to be used in the constraints file.
+    Default: Should be most recent version, except short after a new release (PR's welcome).
+`listen`
+    *host:port* for the WSGI server to listen on.
+    Usually "localhost:8080" for local development or "0.0.0.0:8080" if the port needs to be accessible from the outside.
+    Default: `localhost:8080`
+
+These options can be stored in a `plone-kickstarter.yaml`:
+
+```YML
+    default_context:
+        project_name: 'admin'
+        mode: 'addon'
+        admin_user: 'admin
+```
+
+Pass additional parameters `--no-input --config-file plone-kickstarter.yaml`.
+*cookicutter* takes the stored values or the defaults and does not ask further questions.
+
 ## Usage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ The setup can then be enhanced for your needs.
 
 ### Create a vanilla Plone site
 
+- Ensure Python 3.9 is installed (including pip).
 - Run cookiecutter with option `mode` set to ``standalone``.
 - Enter generated direcory.
-- Create a Pythn 3.9 virtualenv and activate it.
 - Run ``make run``
 
 ### Create a Plone addon
@@ -100,8 +100,6 @@ plonecli create addon acme.foo
 cookiecutter -f https://github.com/bluedynamics/plone-kickstarter.git
 # (select addon mode, otherwse defaults)
 cd acme.foo
-python3.9 -m venv venv
-. venv/activate
 make run
 ```
 
@@ -138,8 +136,6 @@ Enter the created project
 ```bash
     cd acme.foo
 ```
-
-Create a Python 3 *virtualenv* and activate it.
 
 Use the Makefile
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,7 @@
 {
     "project_name": "acme.foo",
     "mode": ["standalone", "addon"],
+    "requirements_out": "requirements-mxdev.txt",
     "admin_user": "admin",
     "admin_password": "",
     "plone_version": "6.0.0a2",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 cwd = Path.cwd()
 
-if "{{ cookiecutter.mode }}" == "standalone":
+requirements_out = "{{ cookiecutter.requirements_out }}"
+if requirements_out != "requirements_barebone.txt":
     current_requirements_file = cwd / "requirements_barebone.txt"
-    renamed_requirements_file = cwd / "requirements.txt"
+    renamed_requirements_file = cwd / "{{ cookiecutter.requirements_out }}"
     current_requirements_file.rename(renamed_requirements_file)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -3,8 +3,7 @@ from pathlib import Path
 
 cwd = Path.cwd()
 
-requirements_out = "{{ cookiecutter.requirements_out }}"
-if requirements_out != "requirements_barebone.txt":
+if "{{ cookiecutter.mode }}" == "standalone":
     current_requirements_file = cwd / "requirements_barebone.txt"
-    renamed_requirements_file = cwd / "{{ cookiecutter.requirements_out }}"
+    renamed_requirements_file = cwd / "requirements.txt"
     current_requirements_file.rename(renamed_requirements_file)

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -16,21 +16,24 @@ OK_COLOR=`tput setaf 2`
 # ERROR_COLOR=`tput setaf 1`
 NO_COLOR=`tput sgr0`
 
-
+##############################################################################
 # Specifcs of this Makefile
-INSTANCE_FOLDER=instance
+CONSTRAINTS=constraints.txt
 {%- if cookiecutter.mode == "addon" %}
 PIP_REQUIREMENTS_IN_FILE=requirements_barebone.txt
+ADDONFOLDER=./src
 {%- else %}
 PIP_REQUIREMENTS_IN_FILE=requirements.txt
 {%- endif %}
+INSTANCE_FOLDER=instance
 
 PIP_PARAMS= --pre --use-deprecated legacy-resolver
+##############################################################################
 
 # targets and prerequisites
 # target has to be one file, otherwise step gets executes for each file separate
-PREPARE_PREREQUISITES=.make-pip.sentinel .make-mxdev.sentinel ${PIP_REQUIREMENTS_IN_FILE} constraints.txt sources.ini{%- if cookiecutter.mode == "addon" %} setup.cfg{%- endif %}
-PREPARE_TARGET=requirements-dev.txt
+PREPARE_PREREQUISITES=${PIP_REQUIREMENTS_IN_FILE} ${CONSTRAINTS} sources.ini{%- if cookiecutter.mode == "addon" %} setup.cfg{%- endif %}
+PREPARE_TARGET={{ cookiecutter.requirements_out }}
 INSTALL_PREREQUSISTES=${PREPARE_TARGET}
 INSTALL_TARGET=.installed.txt
 INSTANCE_PREREQUISITES=${INSTALL_TARGET} instance.yaml
@@ -40,8 +43,6 @@ TEST_PREREQUISITES=${INSTALL_TARGET}
 {%- endif %}
 RUN_PREREQUISITES=${INSTANCE_TARGET}
 
-# for clean, what to remove
-CLEAN_FILES=${INSTALL_PREREQUSISTES} .installed.txt .make-*.sentinel ${INSTANCE_TARGET}
 
 # install and run
 .PHONY: all
@@ -53,20 +54,31 @@ all: {%- if cookiecutter.mode == "addon" %}test {%- endif %}run
 help: ## This help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.make-pip.sentinel: constraints.txt
-	@echo "$(OK_COLOR)Install pip according to constraints.txt$(NO_COLOR)"
-	@pip install -c constraints.txt pip wheel
-	@touch .make-pip.sentinel
+SENTINELFOLDER=.make-sentinels/
+SENTINEL=${SENTINELFOLDER}ABOUT.txt
+${SENTINEL}:
+	@mkdir -p ${SENTINELFOLDER}
+	@echo "Sentinels for the Makefile process." > ${SENTINEL}
 
-.make-mxdev.sentinel: .make-pip.sentinel
+PIP_SENTINEL=${SENTINELFOLDER}pip.sentinel
+${PIP_SENTINEL}: ${CONSTRAINTS} ${SENTINEL}
+	@echo "$(OK_COLOR)Install pip according to ${CONSTRAINTS}$(NO_COLOR)"
+	@pip install -c ${CONSTRAINTS} pip wheel
+	@touch ${PIP_SENTINEL}
+
+MXDEV_SENTINEL=${SENTINELFOLDER}mxdev.sentinel
+${MXDEV_SENTINEL}: ${PIP_SENTINEL}
 	@echo "$(OK_COLOR)Install mxdev$(NO_COLOR)"
-	@pip install -c constraints.txt mxdev
-	@touch .make-mxdev.sentinel
+	@pip install mxdev
+	@touch ${MXDEV_SENTINEL}
 
 .PHONY: prepare
 prepare: ${PREPARE_TARGET} ## prepare soures and dependencies
 
-${PREPARE_TARGET}: ${PREPARE_PREREQUISITES}
+${PREPARE_PREREQUISITES}:
+	@touch $@
+
+${PREPARE_TARGET}: ${MXDEV_SENTINEL} ${PREPARE_PREREQUISITES}
 	@echo "$(OK_COLOR)Prepare sources and dependencies$(NO_COLOR)"
 	@mxdev -c sources.ini
 
@@ -76,15 +88,13 @@ install: ${INSTALL_TARGET} ## pip install all dependencies and scripts
 ${INSTALL_TARGET}: ${PREPARE_TARGET}
 	@echo "$(OK_COLOR)Install dependencies and scripts$(NO_COLOR)"
 	@pip install -r ${PREPARE_TARGET} ${PIP_PARAMS}
-	# @head -2 skel/settings.json >.vscode/settings.json
-	# @python -c "import sys; [print(f'        \"{p}\",') for p in sys.path if p]" >>.vscode/settings.json
-	# @tail -2 skel/settings.json >>.vscode/settings.json
 	@pip freeze >${INSTALL_TARGET}
 
-.make-cookiecutter.sentinel:
+COOKIECUTTER_SENTINEL=${SENTINELFOLDER}cookiecutter.sentinel
+${COOKIECUTTER_SENTINEL}:
 	@echo "$(OK_COLOR)Install cookiecutter$(NO_COLOR)"
 	@pip install git+https://github.com/cookiecutter/cookiecutter.git#egg=cookiecutter
-	@touch .make-cookiecutter.sentinel
+	@touch ${COOKIECUTTER_SENTINEL}
 
 instance.yaml:
 	@touch instance.yaml
@@ -92,33 +102,109 @@ instance.yaml:
 .PHONY: instance
 instance: ${INSTANCE_TARGET} ## create configuration for an zope (plone) instance
 
-${INSTANCE_TARGET}: ${INSTANCE_PREREQUISITES} .make-cookiecutter.sentinel
+${INSTANCE_TARGET}: ${INSTANCE_PREREQUISITES} ${COOKIECUTTER_SENTINEL}
 	@echo "$(OK_COLOR)Create Plone/Zope configuration$(NO_COLOR)"
 	@cookiecutter -f --no-input --config-file instance.yaml https://github.com/bluedynamics/cookiecutter-zope-instance
 
 {%- if cookiecutter.mode == "addon" %}
-.PHONY: test
-test: ${TEST_PREREQUISITES}  ## run tests
-	@echo "$(OK_COLOR)Run addon tests$(NO_COLOR)"
-	@zope-testrunner --test-path=src
 
+TESTRUNNER_SENTINEL=${SENTINELFOLDER}testrunner.sentinel
+${TESTRUNNER_SENTINEL}: ${PIP_SENTINEL}
+	@echo "$(OK_COLOR)Install zope.testrunner$(NO_COLOR)"
+	@pip install zope.testrunner
+	@touch ${TESTRUNNER_SENTINEL}
+
+.PHONY: test
+test: ${TEST_PREREQUISITES} ${TESTRUNNER_SENTINEL} ## run tests
+	@echo "$(OK_COLOR)Run addon tests$(NO_COLOR)"
+	@zope-testrunner --auto-color --auto-progress --test-path=${ADDONFOLDER}
+
+.PHONY: test-ignore-warnings
+test-ignore-warnings: ${TEST_PREREQUISITES} ${TESTRUNNER_SENTINEL}  ## run tests (hide warnins)
+	@echo "$(OK_COLOR)Run addon tests$(NO_COLOR)"
+	@PYTHONWARNINGS=ignore zope-testrunner --auto-color --auto-progress --test-path=${ADDONFOLDER}
+
+BLACK_SENTINEL=${SENTINELFOLDER}black.sentinel
+${BLACK_SENTINEL}: ${PIP_SENTINEL}
+	@echo "$(OK_COLOR)Install black$(NO_COLOR)"
+	@pip install black
+	@touch ${BLACK_SENTINEL}
+
+ISORT_SENTINEL=${SENTINELFOLDER}isort.sentinel
+${ISORT_SENTINEL}: ${PIP_SENTINEL}
+	@echo "$(OK_COLOR)Install isort$(NO_COLOR)"
+	@pip install isort
+	@touch ${ISORT_SENTINEL}
+
+ZPRETTY_SENTINEL=${SENTINELFOLDER}zpretty.sentinel
+${ZPRETTY_SENTINEL}: ${PIP_SENTINEL}
+	@echo "$(OK_COLOR)Install zpretty$(NO_COLOR)"
+	@pip install zpretty
+	@touch ${ZPRETTY_SENTINEL}
+
+.PHONY: apply-style-black
+apply-style-black: ${BLACK_SENTINEL}  ## apply/format code style black (to Python files)
+	@echo "$(OK_COLOR)Apply style black rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
+	@black ${ADDONFOLDER}
+
+.PHONY: apply-style-isort
+apply-style-isort: ${ISORT_SENTINEL} ## apply/format code style isort (sorted imports in Python files)
+	@echo "$(OK_COLOR)Apply style isort rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
+	@isort ${ADDONFOLDER}
+
+.PHONY: apply-style-zpretty
+apply-style-zpretty: ${ZPRETTY_SENTINEL}   ## apply/format code style zpretty (to XML/ZCML files)
+	@echo "$(OK_COLOR)Apply style zpretty rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
+	@find ${ADDONFOLDER} -name "*.zcml"|xargs zpretty -iz
+	@find ${ADDONFOLDER} -name "*.xml"|grep -v locales|xargs zpretty -ix
+
+.PHONY: style ## apply code styles black, isort and zpretty
+style: apply-style-black apply-style-isort apply-style-zpretty
+
+.PHONY: format ## alias for "style"
+style: style
+
+.PHONY: lint-black
+lint-black: ${BLACK_SENTINEL}  ## lint code-style black (to Python files)
+	@echo "$(OK_COLOR)Lint black rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
+	@black --check ${ADDONFOLDER}
+
+.PHONY: lint-isort
+lint-isort: ${ISORT_SENTINEL} ## lint code-style isort (sorted imports in Python files)
+	@echo "$(OK_COLOR)Apply style isort rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
+	@isort --check-only ${ADDONFOLDER}
+
+.PHONY: lint-zpretty
+lint-zpretty: ${ZPRETTY_SENTINEL}   ## lint code-style zpretty (to XML/ZCML files)
+	@echo "$(OK_COLOR)Apply style zpretty rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
+	@find ${ADDONFOLDER} -name "*.zcml"|xargs zpretty --check -z
+	@find ${ADDONFOLDER} -name "*.xml"|grep -v locales|xargs zpretty --check -x
+
+.PHONY: lint ## lint all: check if complies with code-styles black, isort and zpretty
+liny: lint-black lint-isort lint-zpretty
 {%- endif %}
+
 .PHONY: run
-run: ${RUN_PREREQUISITES} ## run Plone
+run: ${RUN_PREREQUISITES} ## run/start Plone
 	@echo "$(OK_COLOR)Run Plone$(NO_COLOR)"
 	@runwsgi -v instance/etc/zope.ini
 
-.PHONY: clean
-clean:  ## remove instance configuration (keeps data)
-	@echo "$(OK_COLOR)Remove Plone/Zope configuration (keeps data) and sentinel files.$(NO_COLOR)"
-	rm ${CLEAN_FILES}
+.PHONY: clean-pyc
+clean-pyc: ## remove Python file artifacts
+	@echo "$(OK_COLOR)Remove Python file artifacts (like byte-code) of code in current directory.$(NO_COLOR)"
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
 
-{%- if cookiecutter.mode == "addon" %}
-.PHONY: style
-style:  ## format code (black, isort, zpretty)
-	@echo "$(OK_COLOR)Apply style guide rules to code in ./src/*$(NO_COLOR)"
-	@isort src
-	@black src
-	@find src -name "*.zcml"|xargs zpretty -iz
-	@find src -name "*.xml"|grep -v locales|xargs zpretty -ix
-{%- endif %}
+.PHONY: clean-make
+clean-make:  ## remove make artifact	@echo "$(OK_COLOR)Remove Plone/Zope configuration (keeps data) and sentinel files.$(NO_COLOR)"
+	rm -rf ${INSTALL_PREREQUSISTES} ${INSTANCE_TARGET} ${SENTINELFOLDER}
+
+.PHONY: clean-instance
+clean-instance:  ## remove instance configuration (keeps data)
+	@echo "$(OK_COLOR)Remove Plone/Zope configuration (keeps data) and sentinel files.$(NO_COLOR)"
+	rm -f ${INSTANCE_TARGET}
+
+.PHONY: clean
+clean:  clean-pyc clean-make clean-instance  ## clean all (except local database and pip installed packages)

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -14,14 +14,17 @@ MAKEFLAGS+=--warn-undefined-variables
 MAKEFLAGS+=--no-builtin-rules
 
 # Colors
+# OK=Green, warn=yellow, error=red
 OK_COLOR=`tput setaf 2`
-# WARN_YELLOW=`tput setaf 3`
-# ERROR_COLOR=`tput setaf 1`
+# WARN_COLOR=`tput setaf 3`
+ERROR_COLOR=`tput setaf 1`
 NO_COLOR=`tput sgr0`
 
 ##############################################################################
 # SETTINGS AND VARIABLE
 # adjust to your project needs
+PROJEKT_NAME={{ cookiecutter.project_name }}
+IMAGE_NAME=${PROJEKT_NAME}
 CONSTRAINTS=constraints.txt
 {%- if cookiecutter.mode == "addon" %}
 PIP_REQUIREMENTS_IN_FILE=requirements_barebone.txt
@@ -175,7 +178,7 @@ apply-style-isort: ${ISORT_SENTINEL} ## apply/format code style isort (sorted im
 .PHONY: apply-style-zpretty
 apply-style-zpretty: ${ZPRETTY_SENTINEL}   ## apply/format code style zpretty (to XML/ZCML files)
 	@echo "$(OK_COLOR)Apply style zpretty rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
-	@find ${ADDONFOLDER} -name "*.zcml"|xargs zpretty -iz
+	@find ${ADDONFOLDER} -name '*.zcml' -exec zpretty --check -z {} +
 	@find ${ADDONFOLDER} -name "*.xml"|grep -v locales|xargs zpretty -ix
 
 .PHONY: style ## apply code styles black, isort and zpretty
@@ -197,8 +200,8 @@ lint-isort: ${ISORT_SENTINEL} ## lint code-style isort (sorted imports in Python
 .PHONY: lint-zpretty
 lint-zpretty: ${ZPRETTY_SENTINEL}   ## lint code-style zpretty (to XML/ZCML files)
 	@echo "$(OK_COLOR)Apply style zpretty rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
-	@find ${ADDONFOLDER} -name "*.zcml"|xargs zpretty --check -z
-	@find ${ADDONFOLDER} -name "*.xml"|grep -v locales|xargs zpretty --check -x
+	@find ${ADDONFOLDER} -name '*.zcml' -exec zpretty --check -z {} +
+	@find ${ADDONFOLDER} -name '*.xml'|grep -v locales|xargs zpretty --check -x
 
 .PHONY: lint ## lint all: check if complies with code-styles black, isort and zpretty
 liny: lint-black lint-isort lint-zpretty
@@ -234,3 +237,15 @@ clean-instance:  ## remove instance configuration (keeps data)
 
 .PHONY: clean
 clean:  clean-pyc clean-make clean-instance  ## clean all (except local database and pip installed packages)
+
+##############################################################################
+# DOCKER/CONTAINER
+
+# this needs a Dockerfile, which is not provided by plone-kickstarter
+.PHONY: build-image
+build-image:  ## Build Docker Image
+ifneq ("$(wildcard Dockerfile)", "")
+	@docker build . -t $(IMAGE_NAME) -f Dockerfile
+else
+	@echo "$(ERROR_COLOR)A 'Dockerfile' is required to build an image.$(NO_COLOR)"
+endif

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -23,15 +23,17 @@ NO_COLOR=`tput sgr0`
 ##############################################################################
 # SETTINGS AND VARIABLE
 # adjust to your project needs
-PROJEKT_NAME={{ cookiecutter.project_name }}
-IMAGE_NAME=${PROJEKT_NAME}
+PROJECT_NAME={{ cookiecutter.project_name }}
+IMAGE_NAME=${PROJECT_NAME}
 CONSTRAINTS=constraints.txt
 {%- if cookiecutter.mode == "addon" %}
 PIP_REQUIREMENTS_IN_FILE=requirements_barebone.txt
-ADDONFOLDER=./src
+ADDONBASE=./
+ADDONFOLDER=${ADDONBASE}src/
 {%- else %}
 PIP_REQUIREMENTS_IN_FILE=requirements.txt
 {%- endif %}
+INSTANCE_YAML=instance.yaml
 INSTANCE_FOLDER=instance
 
 PIP_PARAMS= --pre --use-deprecated legacy-resolver
@@ -39,11 +41,11 @@ PIP_PARAMS= --pre --use-deprecated legacy-resolver
 ##############################################################################
 # targets and prerequisites
 # target has to be one file, otherwise step gets executes for each file separate
-PREPARE_PREREQUISITES=${PIP_REQUIREMENTS_IN_FILE} ${CONSTRAINTS} sources.ini{%- if cookiecutter.mode == "addon" %} setup.cfg{%- endif %}
+PREPARE_PREREQUISITES=${PIP_REQUIREMENTS_IN_FILE} ${CONSTRAINTS} sources.ini{%- if cookiecutter.mode == "addon" %} ${ADDONBASE}setup.cfg{%- endif %}
 PREPARE_TARGET={{ cookiecutter.requirements_out }}
 INSTALL_PREREQUSISTES=${PREPARE_TARGET}
 INSTALL_TARGET=.installed.txt
-INSTANCE_PREREQUISITES=${INSTALL_TARGET} instance.yaml
+INSTANCE_PREREQUISITES=${INSTALL_TARGET} ${INSTANCE_YAML}
 INSTANCE_TARGET=${INSTANCE_FOLDER}/etc/zope.ini ${INSTANCE_FOLDER}/etc/zope.conf ${INSTANCE_FOLDER}/etc/site.zcml
 {%- if cookiecutter.mode == "addon" %}
 TEST_PREREQUISITES=${INSTALL_TARGET}
@@ -64,6 +66,31 @@ help: ## This help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 ##############################################################################
+# targets and prerequisites
+# target has to be one file, otherwise step gets executes for each file separate
+PREPARE_PREREQUISITES=${PIP_REQUIREMENTS_IN_FILE} ${CONSTRAINTS} sources.ini ${ADDONBASE}setup.cfg
+PREPARE_TARGET=requirements-mxdev.txt
+INSTALL_PREREQUSISTES=${PREPARE_TARGET}
+INSTALL_TARGET=.installed.txt
+INSTANCE_PREREQUISITES=${INSTALL_TARGET} ${INSTANCE_YAML}
+INSTANCE_TARGET=${INSTANCE_FOLDER}/etc/zope.ini ${INSTANCE_FOLDER}/etc/zope.conf ${INSTANCE_FOLDER}/etc/site.zcml
+TEST_PREREQUISITES=${INSTALL_TARGET}
+RUN_PREREQUISITES=${INSTANCE_TARGET}
+
+##############################################################################
+# CONVINIENCE
+
+# install and run
+.PHONY: all # full install, test and run
+all:style testrun
+
+# Add the following 'help' target to your Makefile
+# And add help text after each target name starting with '\#\#'
+.PHONY: help
+help: ## This help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+##############################################################################
 # BASE
 
 SENTINELFOLDER=.make-sentinels/
@@ -73,9 +100,24 @@ ${SENTINEL}:
 	@echo "Sentinels for the Makefile process." > ${SENTINEL}
 
 # PYTHON, VENV, PIP
-# installed?
+# venv and pybin
 PYTHON=python3
-ifeq (, $(shell which python ))
+VENV?=on
+ifeq ("${VENV}", "on")
+	VENV_FOLDER?=./venv
+	PYBIN=${VENV_FOLDER}/bin/
+else
+	VENV_FOLDER?=
+	ifneq ("${VENV_FOLDER}", "")
+		PYBIN=${VENV_FOLDER}/bin/
+		PYTHON=${PYBIN}python
+	else
+		PYBIN=
+	endif
+endif
+
+# installed?
+ifeq (, $(shell which $(PYTHON) ))
   $(error "PYTHON=$(PYTHON) not found in $(PATH)")
 endif
 
@@ -86,14 +128,18 @@ ifeq ($(PYTHON_VERSION_OK),0)
   $(error "Need python $(PYTHON_VERSION) >= $(PYTHON_VERSION_MIN)")
 endif
 
-PYBIN=./venv/bin/
-VENV=${PYBIN}python
-${VENV}:
-	@echo "$(OK_COLOR)Setup Python Virtual Environment under './venv' $(NO_COLOR)"
-	@${PYTHON} -m venv venv
+VENV_SENTINEL=${SENTINELFOLDER}venv.sentinel
+${VENV_SENTINEL}: ${SENTINEL}
+ifeq ("${VENV}", "on")
+	@echo "$(OK_COLOR)Setup Python Virtual Environment under '${VENV_FOLDER}' $(NO_COLOR)"
+	@${PYTHON} -m venv ${VENV_FOLDER}
+else
+	@echo "$(OK_COLOR)Use current local or global Python: `which ${PYTHON}` $(NO_COLOR)"
+endif
+	@touch ${VENV_SENTINEL}
 
 PIP_SENTINEL=${SENTINELFOLDER}pip.sentinel
-${PIP_SENTINEL}: ${VENV} ${CONSTRAINTS} ${SENTINEL}
+${PIP_SENTINEL}: ${VENV_SENTINEL} ${CONSTRAINTS} ${SENTINEL}
 	@echo "$(OK_COLOR)Install pip according to ${CONSTRAINTS}$(NO_COLOR)"
 	@${PYBIN}pip install -c ${CONSTRAINTS} pip wheel
 	@touch ${PIP_SENTINEL}
@@ -134,15 +180,15 @@ ${COOKIECUTTER_SENTINEL}:
 	@${PYBIN}pip install git+https://github.com/cookiecutter/cookiecutter.git#egg=cookiecutter
 	@touch ${COOKIECUTTER_SENTINEL}
 
-instance.yaml:
-	@touch instance.yaml
+${INSTANCE_YAML}:
+	@touch ${INSTANCE_YAML}
 
 .PHONY: instance
 instance: ${INSTANCE_TARGET} ## create configuration for an zope (plone) instance
 
 ${INSTANCE_TARGET}: ${INSTANCE_PREREQUISITES} ${COOKIECUTTER_SENTINEL}
 	@echo "$(OK_COLOR)Create Plone/Zope configuration$(NO_COLOR)"
-	@${PYBIN}cookiecutter -f --no-input --config-file instance.yaml https://github.com/bluedynamics/cookiecutter-zope-instance
+	@${PYBIN}cookiecutter -f --no-input --config-file ${INSTANCE_YAML} https://github.com/bluedynamics/cookiecutter-zope-instance
 
 {%- if cookiecutter.mode == "addon" %}
 ##############################################################################
@@ -240,7 +286,12 @@ run: ${RUN_PREREQUISITES} ## run/start Plone
 # CLEAN
 .PHONY: clean-venv
 clean-venv: ## remove Python virtual environment
-	rm -rf ./venv ${SENTINELFOLDER}/pip*.sentinel
+ifeq ("${VENV}", "on")
+	@echo "$(OK_COLOR)Remove Virtualenv.$(NO_COLOR)"
+	rm -rf ${VENV_FOLDER} ${SENTINELFOLDER}/pip*.sentinel ${VENV_SENTINEL}
+else:
+	@echo "$(OK_WARN)No self-created Python virtualenv at '${VENV_FOLDER}'! Nothing to do.$(NO_COLOR)"
+endif
 
 .PHONY: clean-pyc
 clean-pyc: ## remove Python file artifacts

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -16,7 +16,7 @@ MAKEFLAGS+=--no-builtin-rules
 # Colors
 # OK=Green, warn=yellow, error=red
 OK_COLOR=`tput setaf 2`
-# WARN_COLOR=`tput setaf 3`
+WARN_COLOR=`tput setaf 3`
 ERROR_COLOR=`tput setaf 1`
 NO_COLOR=`tput sgr0`
 
@@ -72,19 +72,39 @@ ${SENTINEL}:
 	@mkdir -p ${SENTINELFOLDER}
 	@echo "Sentinels for the Makefile process." > ${SENTINEL}
 
+# PYTHON, VENV, PIP
+# installed?
+PYTHON=python3
+ifeq (, $(shell which python ))
+  $(error "PYTHON=$(PYTHON) not found in $(PATH)")
+endif
+
+# version ok?
+PYTHON_VERSION_MIN=3.7
+PYTHON_VERSION_OK=$(shell $(PYTHON) -c 'import sys; print(int(float("%d.%d"% sys.version_info[0:2]) >= float($(PYTHON_VERSION_MIN))))' )
+ifeq ($(PYTHON_VERSION_OK),0)
+  $(error "Need python $(PYTHON_VERSION) >= $(PYTHON_VERSION_MIN)")
+endif
+
+PYBIN=./venv/bin/
+VENV=${PYBIN}python
+${VENV}:
+	@echo "$(OK_COLOR)Setup Python Virtual Environment under './venv' $(NO_COLOR)"
+	@${PYTHON} -m venv venv
+
 PIP_SENTINEL=${SENTINELFOLDER}pip.sentinel
-${PIP_SENTINEL}: ${CONSTRAINTS} ${SENTINEL}
+${PIP_SENTINEL}: ${VENV} ${CONSTRAINTS} ${SENTINEL}
 	@echo "$(OK_COLOR)Install pip according to ${CONSTRAINTS}$(NO_COLOR)"
-	@pip install -c ${CONSTRAINTS} pip wheel
+	@${PYBIN}pip install -c ${CONSTRAINTS} pip wheel
 	@touch ${PIP_SENTINEL}
 
 ##############################################################################
 # MXDEV
 
-MXDEV_SENTINEL=${SENTINELFOLDER}mxdev.sentinel
+MXDEV_SENTINEL=${SENTINELFOLDER}pip-mxdev.sentinel
 ${MXDEV_SENTINEL}: ${PIP_SENTINEL}
 	@echo "$(OK_COLOR)Install mxdev$(NO_COLOR)"
-	@pip install mxdev
+	@${PYBIN}pip install mxdev
 	@touch ${MXDEV_SENTINEL}
 
 .PHONY: prepare
@@ -95,23 +115,23 @@ ${PREPARE_PREREQUISITES}:
 
 ${PREPARE_TARGET}: ${MXDEV_SENTINEL} ${PREPARE_PREREQUISITES}
 	@echo "$(OK_COLOR)Prepare sources and dependencies$(NO_COLOR)"
-	@mxdev -c sources.ini
+	@${PYBIN}mxdev -c sources.ini
 
 .PHONY: install
 install: ${INSTALL_TARGET} ## pip install all dependencies and scripts
 
 ${INSTALL_TARGET}: ${PREPARE_TARGET}
 	@echo "$(OK_COLOR)Install dependencies and scripts$(NO_COLOR)"
-	@pip install -r ${PREPARE_TARGET} ${PIP_PARAMS}
-	@pip freeze >${INSTALL_TARGET}
+	@${PYBIN}pip install -r ${PREPARE_TARGET} ${PIP_PARAMS}
+	@${PYBIN}pip freeze >${INSTALL_TARGET}
 
 ##############################################################################
 # INSTANCE
 
-COOKIECUTTER_SENTINEL=${SENTINELFOLDER}cookiecutter.sentinel
+COOKIECUTTER_SENTINEL=${SENTINELFOLDER}pip-cookiecutter.sentinel
 ${COOKIECUTTER_SENTINEL}:
 	@echo "$(OK_COLOR)Install cookiecutter$(NO_COLOR)"
-	@pip install git+https://github.com/cookiecutter/cookiecutter.git#egg=cookiecutter
+	@${PYBIN}pip install git+https://github.com/cookiecutter/cookiecutter.git#egg=cookiecutter
 	@touch ${COOKIECUTTER_SENTINEL}
 
 instance.yaml:
@@ -122,22 +142,22 @@ instance: ${INSTANCE_TARGET} ## create configuration for an zope (plone) instanc
 
 ${INSTANCE_TARGET}: ${INSTANCE_PREREQUISITES} ${COOKIECUTTER_SENTINEL}
 	@echo "$(OK_COLOR)Create Plone/Zope configuration$(NO_COLOR)"
-	@cookiecutter -f --no-input --config-file instance.yaml https://github.com/bluedynamics/cookiecutter-zope-instance
+	@${PYBIN}cookiecutter -f --no-input --config-file instance.yaml https://github.com/bluedynamics/cookiecutter-zope-instance
 
 {%- if cookiecutter.mode == "addon" %}
 ##############################################################################
 # TESTING
 
-TESTRUNNER_SENTINEL=${SENTINELFOLDER}testrunner.sentinel
+TESTRUNNER_SENTINEL=${SENTINELFOLDER}pip-testrunner.sentinel
 ${TESTRUNNER_SENTINEL}: ${PIP_SENTINEL}
 	@echo "$(OK_COLOR)Install zope.testrunner$(NO_COLOR)"
-	@pip install zope.testrunner
+	@${PYBIN}pip install zope.testrunner
 	@touch ${TESTRUNNER_SENTINEL}
 
 .PHONY: test
 test: ${TEST_PREREQUISITES} ${TESTRUNNER_SENTINEL} ## run tests
 	@echo "$(OK_COLOR)Run addon tests$(NO_COLOR)"
-	@zope-testrunner --auto-color --auto-progress --test-path=${ADDONFOLDER}
+	@${PYBIN}zope-testrunner --auto-color --auto-progress --test-path=${ADDONFOLDER}
 
 .PHONY: test-ignore-warnings
 test-ignore-warnings: ${TEST_PREREQUISITES} ${TESTRUNNER_SENTINEL}  ## run tests (hide warnins)
@@ -147,64 +167,65 @@ test-ignore-warnings: ${TEST_PREREQUISITES} ${TESTRUNNER_SENTINEL}  ## run tests
 ##############################################################################
 # CODE FORMATTING
 
-BLACK_SENTINEL=${SENTINELFOLDER}black.sentinel
+BLACK_SENTINEL=${SENTINELFOLDER}pip-black.sentinel
 ${BLACK_SENTINEL}: ${PIP_SENTINEL}
 	@echo "$(OK_COLOR)Install black$(NO_COLOR)"
-	@pip install black
+	@${PYBIN}pip install black
 	@touch ${BLACK_SENTINEL}
 
-ISORT_SENTINEL=${SENTINELFOLDER}isort.sentinel
+ISORT_SENTINEL=${SENTINELFOLDER}pip-isort.sentinel
 ${ISORT_SENTINEL}: ${PIP_SENTINEL}
 	@echo "$(OK_COLOR)Install isort$(NO_COLOR)"
-	@pip install isort
+	@${PYBIN}pip install isort
 	@touch ${ISORT_SENTINEL}
 
-ZPRETTY_SENTINEL=${SENTINELFOLDER}zpretty.sentinel
+ZPRETTY_SENTINEL=${SENTINELFOLDER}pip-zpretty.sentinel
 ${ZPRETTY_SENTINEL}: ${PIP_SENTINEL}
 	@echo "$(OK_COLOR)Install zpretty$(NO_COLOR)"
-	@pip install zpretty
+	@${PYBIN}pip install zpretty
 	@touch ${ZPRETTY_SENTINEL}
 
 .PHONY: apply-style-black
 apply-style-black: ${BLACK_SENTINEL}  ## apply/format code style black (to Python files)
 	@echo "$(OK_COLOR)Apply style black rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
-	@black ${ADDONFOLDER}
+	@${PYBIN}black ${ADDONFOLDER}
 
 .PHONY: apply-style-isort
 apply-style-isort: ${ISORT_SENTINEL} ## apply/format code style isort (sorted imports in Python files)
 	@echo "$(OK_COLOR)Apply style isort rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
-	@isort ${ADDONFOLDER}
+	@${PYBIN}isort ${ADDONFOLDER}
 
 .PHONY: apply-style-zpretty
 apply-style-zpretty: ${ZPRETTY_SENTINEL}   ## apply/format code style zpretty (to XML/ZCML files)
 	@echo "$(OK_COLOR)Apply style zpretty rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
-	@find ${ADDONFOLDER} -name '*.zcml' -exec zpretty --check -z {} +
-	@find ${ADDONFOLDER} -name "*.xml"|grep -v locales|xargs zpretty -ix
+	@find ${ADDONFOLDER} -name '*.zcml' -exec ${PYBIN}zpretty --check -z {} +
+	@find ${ADDONFOLDER} -name "*.xml"|grep -v locales|xargs ${PYBIN}zpretty -ix
 
 .PHONY: style ## apply code styles black, isort and zpretty
 style: apply-style-black apply-style-isort apply-style-zpretty
 
 .PHONY: format ## alias for "style"
-style: style
+FORMATTING: style
 
 .PHONY: lint-black
 lint-black: ${BLACK_SENTINEL}  ## lint code-style black (to Python files)
 	@echo "$(OK_COLOR)Lint black rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
-	@black --check ${ADDONFOLDER}
+	@${PYBIN}black --check ${ADDONFOLDER}
 
 .PHONY: lint-isort
 lint-isort: ${ISORT_SENTINEL} ## lint code-style isort (sorted imports in Python files)
 	@echo "$(OK_COLOR)Apply style isort rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
-	@isort --check-only ${ADDONFOLDER}
+	@${PYBIN}isort --check-only ${ADDONFOLDER}
 
-.PHONY: lint-zpretty
-lint-zpretty: ${ZPRETTY_SENTINEL}   ## lint code-style zpretty (to XML/ZCML files)
-	@echo "$(OK_COLOR)Apply style zpretty rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
-	@find ${ADDONFOLDER} -name '*.zcml' -exec zpretty --check -z {} +
-	@find ${ADDONFOLDER} -name '*.xml'|grep -v locales|xargs zpretty --check -x
+# waiting for a release
+# .PHONY: lint-zpretty
+# lint-zpretty: ${ZPRETTY_SENTINEL}   ## lint code-style zpretty (to XML/ZCML files)
+# 	@echo "$(OK_COLOR)Apply style zpretty rules to code in ${ADDONFOLDER}/*$(NO_COLOR)"
+# 	@find ${ADDONFOLDER} -name '*.zcml' -exec ${PYBIN}zpretty --check -z {} +
+# 	@find ${ADDONFOLDER} -name '*.xml'|grep -v locales|xargs zpretty --check -x
 
 .PHONY: lint ## lint all: check if complies with code-styles black, isort and zpretty
-liny: lint-black lint-isort lint-zpretty
+lint: lint-black lint-isort
 {%- endif %}
 
 ##############################################################################
@@ -213,10 +234,13 @@ liny: lint-black lint-isort lint-zpretty
 .PHONY: run
 run: ${RUN_PREREQUISITES} ## run/start Plone
 	@echo "$(OK_COLOR)Run Plone$(NO_COLOR)"
-	@runwsgi -v instance/etc/zope.ini
+	@${PYBIN}runwsgi -v instance/etc/zope.ini
 
 ##############################################################################
 # CLEAN
+.PHONY: clean-venv
+clean-venv: ## remove Python virtual environment
+	rm -rf ./venv ${SENTINELFOLDER}/pip*.sentinel
 
 .PHONY: clean-pyc
 clean-pyc: ## remove Python file artifacts
@@ -236,7 +260,7 @@ clean-instance:  ## remove instance configuration (keeps data)
 	rm -f ${INSTANCE_TARGET}
 
 .PHONY: clean
-clean:  clean-pyc clean-make clean-instance  ## clean all (except local database and pip installed packages)
+clean:  clean-venv clean-pyc clean-make clean-instance   ## clean all (except local database and pip installed packages)
 
 ##############################################################################
 # DOCKER/CONTAINER

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -1,5 +1,8 @@
 # Makefile to configure and run Plone instance
 
+##############################################################################
+# SETUP MAKE
+
 ## Defensive settings for make: https://tech.davis-hansson.com/p/make/
 SHELL:=bash
 .ONESHELL:
@@ -17,7 +20,8 @@ OK_COLOR=`tput setaf 2`
 NO_COLOR=`tput sgr0`
 
 ##############################################################################
-# Specifcs of this Makefile
+# SETTINGS AND VARIABLE
+# adjust to your project needs
 CONSTRAINTS=constraints.txt
 {%- if cookiecutter.mode == "addon" %}
 PIP_REQUIREMENTS_IN_FILE=requirements_barebone.txt
@@ -28,8 +32,8 @@ PIP_REQUIREMENTS_IN_FILE=requirements.txt
 INSTANCE_FOLDER=instance
 
 PIP_PARAMS= --pre --use-deprecated legacy-resolver
-##############################################################################
 
+##############################################################################
 # targets and prerequisites
 # target has to be one file, otherwise step gets executes for each file separate
 PREPARE_PREREQUISITES=${PIP_REQUIREMENTS_IN_FILE} ${CONSTRAINTS} sources.ini{%- if cookiecutter.mode == "addon" %} setup.cfg{%- endif %}
@@ -43,16 +47,21 @@ TEST_PREREQUISITES=${INSTALL_TARGET}
 {%- endif %}
 RUN_PREREQUISITES=${INSTANCE_TARGET}
 
+##############################################################################
+# CONVINIENCE
 
 # install and run
-.PHONY: all
-all: {%- if cookiecutter.mode == "addon" %}test {%- endif %}run
+.PHONY: all # full install, test and run
+all: {%- if cookiecutter.mode == "addon" %}style test {%- endif %}run
 
 # Add the following 'help' target to your Makefile
 # And add help text after each target name starting with '\#\#'
 .PHONY: help
 help: ## This help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+##############################################################################
+# BASE
 
 SENTINELFOLDER=.make-sentinels/
 SENTINEL=${SENTINELFOLDER}ABOUT.txt
@@ -65,6 +74,9 @@ ${PIP_SENTINEL}: ${CONSTRAINTS} ${SENTINEL}
 	@echo "$(OK_COLOR)Install pip according to ${CONSTRAINTS}$(NO_COLOR)"
 	@pip install -c ${CONSTRAINTS} pip wheel
 	@touch ${PIP_SENTINEL}
+
+##############################################################################
+# MXDEV
 
 MXDEV_SENTINEL=${SENTINELFOLDER}mxdev.sentinel
 ${MXDEV_SENTINEL}: ${PIP_SENTINEL}
@@ -90,6 +102,9 @@ ${INSTALL_TARGET}: ${PREPARE_TARGET}
 	@pip install -r ${PREPARE_TARGET} ${PIP_PARAMS}
 	@pip freeze >${INSTALL_TARGET}
 
+##############################################################################
+# INSTANCE
+
 COOKIECUTTER_SENTINEL=${SENTINELFOLDER}cookiecutter.sentinel
 ${COOKIECUTTER_SENTINEL}:
 	@echo "$(OK_COLOR)Install cookiecutter$(NO_COLOR)"
@@ -107,6 +122,8 @@ ${INSTANCE_TARGET}: ${INSTANCE_PREREQUISITES} ${COOKIECUTTER_SENTINEL}
 	@cookiecutter -f --no-input --config-file instance.yaml https://github.com/bluedynamics/cookiecutter-zope-instance
 
 {%- if cookiecutter.mode == "addon" %}
+##############################################################################
+# TESTING
 
 TESTRUNNER_SENTINEL=${SENTINELFOLDER}testrunner.sentinel
 ${TESTRUNNER_SENTINEL}: ${PIP_SENTINEL}
@@ -123,6 +140,9 @@ test: ${TEST_PREREQUISITES} ${TESTRUNNER_SENTINEL} ## run tests
 test-ignore-warnings: ${TEST_PREREQUISITES} ${TESTRUNNER_SENTINEL}  ## run tests (hide warnins)
 	@echo "$(OK_COLOR)Run addon tests$(NO_COLOR)"
 	@PYTHONWARNINGS=ignore zope-testrunner --auto-color --auto-progress --test-path=${ADDONFOLDER}
+
+##############################################################################
+# CODE FORMATTING
 
 BLACK_SENTINEL=${SENTINELFOLDER}black.sentinel
 ${BLACK_SENTINEL}: ${PIP_SENTINEL}
@@ -184,10 +204,16 @@ lint-zpretty: ${ZPRETTY_SENTINEL}   ## lint code-style zpretty (to XML/ZCML file
 liny: lint-black lint-isort lint-zpretty
 {%- endif %}
 
+##############################################################################
+# RUN
+
 .PHONY: run
 run: ${RUN_PREREQUISITES} ## run/start Plone
 	@echo "$(OK_COLOR)Run Plone$(NO_COLOR)"
 	@runwsgi -v instance/etc/zope.ini
+
+##############################################################################
+# CLEAN
 
 .PHONY: clean-pyc
 clean-pyc: ## remove Python file artifacts

--- a/{{cookiecutter.project_name}}/README_MAKE.md
+++ b/{{cookiecutter.project_name}}/README_MAKE.md
@@ -35,7 +35,21 @@ Order for ``make run`` is: *prepare*, *install*, *instance*, *run*.
 The Makefile is built to detect changes.
 At the first ``make run`` all steps are excuted.
 Subsequent calls are only starting the applicaton server in the *run* step.
-If one of the input file is changed, steps needed to take those changes into effect are executed again.
+If one of the input file is changed, steps needed to take those changes into effect are executed again.\
+
+## Python
+
+The Makefile support different modes of Python:
+
+1. Create new virtualenv under `./venv` (default) from a global Python 3. `python3` is expected to be in the PATH.
+2. Like (1), but the `VENV_FOLDER` is passed to every *make* call: `make VENV_FOLDER=./some_folder/ install`.
+3. `make VENV=off install`: Direct usage of current configure Python 3 environment.
+   Like if one uses *pyenv* or another already activated virtual environment, or in CI if the environment is alredy isolated.
+4. Like (3), but the environment is not activated, so we need to point *make* to the location with `make VENV=off VENV_FOLDER=~/myenv/myproject_venv` or alike.
+
+**Attention:** if those paramters are used, they *must* be passed to every make call!
+
+**Hint:** Edit the `Makefile` and look for `VENV?=on` (which sets the default). And `VENV_FOLDER?=` (look for the if before) and adjust to your needs.
 
 ## Files
 

--- a/{{cookiecutter.project_name}}/sources.ini
+++ b/{{cookiecutter.project_name}}/sources.ini
@@ -9,6 +9,7 @@
 {%- if cookiecutter.mode == "addon" %}
 requirements-in = requirements_barebone.txt
 {%- endif %}
+requirements-out = {{ cookiecutter.requirements_out }}
 
 # variables
 github = git+ssh://git@github.com/


### PR DESCRIPTION
- sentinel files are all now in a subfolder with a text file explaining what it is.
- black, isort and zpretty can be run separate (like one would in CI) and also those got a check mode
- requirements-out has now a different default name and can be configured.
- added targets for input files to circumvent errors
